### PR TITLE
Removed reference to nonexistant file

### DIFF
--- a/cluster-primer/kustomization.yaml
+++ b/cluster-primer/kustomization.yaml
@@ -18,4 +18,3 @@ resources:
 - gitops/rbac/cluster-role-priviledged.yaml
 - gitops/rbac/cluster-rolebinding-azure-key.yaml
 - gitops/rbac/cluster-rolebinding-kyverno.yaml
-- ignored/azure-secret.yaml


### PR DESCRIPTION
I ran into this error:

```
$ oc apply -k cluster-primer 
error: accumulating resources: accumulation err='accumulating resources from 'ignored/azure-secret.yaml': evalsymlink failure on '/home/kechung/Git/aro-hello-chris-tekton-chains/cluster-primer/ignored/azure-secret.yaml' : lstat /home/kechung/Git/aro-hello-chris-tekton-chains/cluster-primer/ignored: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/home/kechung/Git/aro-hello-chris-tekton-chains/cluster-primer/ignored/azure-secret.yaml' : lstat /home/kechung/Git/aro-hello-chris-tekton-chains/cluster-primer/ignored: no such file or directory
```

Looks like this file doesn't exist in `kustomization.yaml` so I removed the reference to it:
```
- ignored/azure-secret.yaml
```